### PR TITLE
fix tap syntax

### DIFF
--- a/tap.js
+++ b/tap.js
@@ -2,8 +2,10 @@
 var yamlish = require('yamlish');
 
 module.exports = function (results) {
-	var ret = '\nTAP version 13\n';
+	var ret = 'TAP version 13\n';
 	var total = 0;
+
+	ret += '\n1..{total}\n';
 
 	results.forEach(function (result) {
 		var messages = result.messages;
@@ -19,17 +21,17 @@ module.exports = function (results) {
 				severity = 'error';
 			}
 
-			return 'not ok ' + (++total) + '\n    ---' + yamlish.encode({
-				message: el.message,
+			return '\nnot ok ' + (++total) + '\n    ---' + yamlish.encode({
+				message: el.message.replace(/'/g, ''),
 				severity: severity,
 				file: result.filePath,
 				line: el.line || 0,
 				name: el.ruleId
-			}) + '\n    ...\n';
+			}) + '\n    ...';
 		}).join('\n') + '\n';
 	});
 
-	ret += '1..' + total;
+	ret = ret.replace(/\{.*\}/, total);
 
 	return ret;
 };


### PR DESCRIPTION
I am using estlint-tap along with Jenkins TAP Plugin and I found it didn't worked because of some problem parsing the tap stream.

using [this validator](http://instanttap.appspot.com) and [this jenkins plugin](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin) I tested the example you show in the readme file of this repo and it didn't worked.

BAD:

```
TAP version 13
not ok 1
    ---
    message:  ‘require' is not defined.
    severity: error
    file:         tap.js
    line:        2
    name:     no-undef
    …
1..1
```

In TAP, the number of tests have to be on top like this:

This does validates and works on the plugin

```
TAP version 13
1..1
not ok 1
    ---
    message:  ‘require' is not defined.
    severity:  error
    file:         tap.js
    line:        2
    name:     no-undef
    …
```

After validating only one error I tried to validate two or more this way, but also didn't work because of a parser issue I don't yet understand and that is if you have two tests and remove the single quotes of the first `'require'` the format is well parsed, if not it won't.

So in this pull request I fix the first issue about the position of the total tests run, but also removing all single quotes from the message.

Please consider this changes, since is the only way it is working in my Jenkins with the TAP plugin.
